### PR TITLE
Updated dependencies and unit-tests

### DIFF
--- a/ezdb.py
+++ b/ezdb.py
@@ -5,7 +5,7 @@
 # @Email:  george raven community at pm dot me
 # @Filename: ezdb.py
 # @Last modified by:   archer
-# @Last modified time: 2020-04-09T09:49:42+01:00
+# @Last modified time: 2020-04-09T20:19:04+01:00
 # @License: Please see LICENSE in project root
 
 from __future__ import print_function, absolute_import   # python 2-3 compat
@@ -752,18 +752,25 @@ def _mongo_unit_test():
 
 class Mongo_tests(unittest.TestCase):
     """Unit test class aggregating all tests for the Mongo class"""
+    import shutil
 
     def setUp(self):
         """Predefined setUp function for preparing tests, in our case
         creating the database."""
         self.db_path = "./unit_test_db"
-        db = Mongo({"pylog": null_printer, "db_path": self.db_path,
-                    "db_log_path": self.db_path})
+        self.db = Mongo({"pylog": null_printer, "db_path": self.db_path,
+                         "db_log_path": self.db_path})
+        self.db.init()
+        self.db.start()
+        self.assertTrue(os.path.isdir(self.db_path))
 
     def tearDown(self):
         """Predefined tearDown function for cleaning up after tests,
         in our case deleting any generated db files."""
-        pass
+        self.db.stop()
+        if(self.db_path is not None):
+            self.shutil.rmtree(self.db_path)
+        self.assertFalse(os.path.isdir(self.db_path))
 
     def test_init(self):
         db = Mongo({"pylog": null_printer})

--- a/ezdb.py
+++ b/ezdb.py
@@ -5,7 +5,7 @@
 # @Email:  george raven community at pm dot me
 # @Filename: ezdb.py
 # @Last modified by:   archer
-# @Last modified time: 2020-04-09T20:19:04+01:00
+# @Last modified time: 2020-04-09T20:47:27+01:00
 # @License: Please see LICENSE in project root
 
 from __future__ import print_function, absolute_import   # python 2-3 compat
@@ -62,7 +62,7 @@ class Mongo(object):
             "db_batch_size": 32,
             "pylog": logger if logger is not None else print,
             "db": None,
-            "db_pipeline": None,
+            "db_pipeline": [],
             "gfs": None,
             # replica options section
             "db_replica_set_name": None,
@@ -540,6 +540,7 @@ class Mongo(object):
         """
         db_pipeline = db_pipeline if db_pipeline is not None else \
             self.args["db_pipeline"]
+        db_pipeline = db_pipeline if db_pipeline is not None else []
         db_collection_name = db_collection_name if db_collection_name is not \
             None else self.args["db_collection_name"]
         db = db if db is not None else self.args["db"]
@@ -772,10 +773,15 @@ class Mongo_tests(unittest.TestCase):
             self.shutil.rmtree(self.db_path)
         self.assertFalse(os.path.isdir(self.db_path))
 
-    def test_init(self):
+    def test_dump(self):
         db = Mongo({"pylog": null_printer})
-        db.debug()
         self.assertIsInstance(db, Mongo)
+        db.connect()
+        db.dump(db_collection_name="test", data={"success": 1})
+        cursor = db.getCursor(db_collection_name="test")
+        for batch in db.getBatches(db_data_cursor=cursor):
+            for doc in batch:
+                self.assertEqual(doc["success"], 1)
 
 
 def null_printer(*text, log_min_level=None,

--- a/ezdb.py
+++ b/ezdb.py
@@ -5,7 +5,7 @@
 # @Email:  george raven community at pm dot me
 # @Filename: ezdb.py
 # @Last modified by:   archer
-# @Last modified time: 2020-04-09T20:47:27+01:00
+# @Last modified time: 2020-04-09T20:51:27+01:00
 # @License: Please see LICENSE in project root
 
 from __future__ import print_function, absolute_import   # python 2-3 compat
@@ -780,6 +780,7 @@ class Mongo_tests(unittest.TestCase):
         db.dump(db_collection_name="test", data={"success": 1})
         cursor = db.getCursor(db_collection_name="test")
         for batch in db.getBatches(db_data_cursor=cursor):
+            self.assertEqual(len(batch), 1)
             for doc in batch:
                 self.assertEqual(doc["success"], 1)
 

--- a/ezdb.py
+++ b/ezdb.py
@@ -5,7 +5,7 @@
 # @Email:  george raven community at pm dot me
 # @Filename: ezdb.py
 # @Last modified by:   archer
-# @Last modified time: 2020-04-09T09:27:40+01:00
+# @Last modified time: 2020-04-09T09:49:42+01:00
 # @License: Please see LICENSE in project root
 
 from __future__ import print_function, absolute_import   # python 2-3 compat
@@ -752,6 +752,18 @@ def _mongo_unit_test():
 
 class Mongo_tests(unittest.TestCase):
     """Unit test class aggregating all tests for the Mongo class"""
+
+    def setUp(self):
+        """Predefined setUp function for preparing tests, in our case
+        creating the database."""
+        self.db_path = "./unit_test_db"
+        db = Mongo({"pylog": null_printer, "db_path": self.db_path,
+                    "db_log_path": self.db_path})
+
+    def tearDown(self):
+        """Predefined tearDown function for cleaning up after tests,
+        in our case deleting any generated db files."""
+        pass
 
     def test_init(self):
         db = Mongo({"pylog": null_printer})

--- a/ezdb.py
+++ b/ezdb.py
@@ -5,7 +5,7 @@
 # @Email:  george raven community at pm dot me
 # @Filename: ezdb.py
 # @Last modified by:   archer
-# @Last modified time: 2020-04-08T14:19:00+01:00
+# @Last modified time: 2020-04-09T09:27:40+01:00
 # @License: Please see LICENSE in project root
 
 from __future__ import print_function, absolute_import   # python 2-3 compat
@@ -15,6 +15,7 @@ import time
 from pymongo import MongoClient, errors, database, command_cursor
 import gridfs
 import re
+import unittest
 
 
 class Mongo(object):
@@ -749,5 +750,21 @@ def _mongo_unit_test():
     db.stop()
 
 
-if(__name__ == "__main__"):
-    _mongo_unit_test()
+class Mongo_tests(unittest.TestCase):
+    """Unit test class aggregating all tests for the Mongo class"""
+
+    def test_init(self):
+        db = Mongo({"pylog": null_printer})
+        db.debug()
+        self.assertIsInstance(db, Mongo)
+
+
+def null_printer(*text, log_min_level=None,
+                 log_delimiter=None):
+    # do absoluteley nothing, i.e dont print
+    pass
+
+
+if __name__ == "__main__":
+    # run all the unit-tests
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-ConfigArgParse>=0.14.0
 pymongo>=3.10.1


### PR DESCRIPTION
We have added new unit-tests following pythons standard unittest framework.
We no longer require ConfigArgParse for this single library file, so we can safely remove it.