### PR TITLE
Unit test friendify and deep copy merging

### DIFF
--- a/docs/source/mongo.rst
+++ b/docs/source/mongo.rst
@@ -25,6 +25,11 @@ Connecting to and dumping data to a database using normal mongodb requests.
 .. literalinclude:: ../../unit_test.py
     :pyobject: Mongo_tests.test_dump
 
+Using Gridfs to dump larger files in chunks to database.
+
+.. literalinclude:: ../../unit_test.py
+    :pyobject: Mongo_tests.test_gridfs
+
 Completely removing the database, this completely removes all your data.
 
 .. literalinclude:: ../../unit_test.py

--- a/ezdb/mongo.py
+++ b/ezdb/mongo.py
@@ -12,6 +12,7 @@
 import os
 import subprocess
 import time
+import copy
 from pymongo import MongoClient, errors, database, command_cursor
 import gridfs
 import re
@@ -513,7 +514,8 @@ class Mongo(object):
                             "db": database.Database, "return": None}
 
     def _mergeDicts(self, *dicts):
-        """Given multiple dictionaries, merge together in order."""
+        """Given multiple dictionaries, deep copy, merge together in order."""
+        dicts = copy.deepcopy(dicts)
         result = {}
         for dictionary in dicts:
             result.update(dictionary)  # merge each dictionary in order

--- a/unit_test.py
+++ b/unit_test.py
@@ -25,12 +25,17 @@ class Mongo_tests(unittest.TestCase):
         import os
         from ezdb.mongo import Mongo
 
-        self.db_path = "./unit_test_db"
-        self.db = Mongo({"pylog": null_printer, "db_path": self.db_path,
-                         "db_log_path": self.db_path})
-        self.db.init()
-        self.db.start()
-        self.assertTrue(os.path.isdir(self.db_path))
+        # the path and directory we want to use to store the database files
+        db_path = "./unit_test_db"
+        db = Mongo({"pylog": null_printer, "db_path": db_path,
+                    "db_log_path": db_path})
+        # initialise the database files and create a basic user
+        db.init()
+        # start the database with authenticaton
+        db.start()
+
+        # for tests only to check db directory is created
+        self.assertTrue(os.path.isdir(db_path))
 
     def tearDown(self):
         """Predefined tearDown function for cleaning up after tests,
@@ -39,10 +44,15 @@ class Mongo_tests(unittest.TestCase):
         import shutil
         from ezdb.mongo import Mongo
 
-        self.db.stop()
-        if(self.db_path is not None):
-            shutil.rmtree(self.db_path)
-        self.assertFalse(os.path.isdir(self.db_path))
+        db_path = "./unit_test_db"
+        db = Mongo({"pylog": null_printer, "db_path": db_path,
+                    "db_log_path": db_path})
+        db.stop()
+        if(db_path is not None):
+            shutil.rmtree(db_path)
+
+        # for tests only to check db directory has been removed
+        self.assertFalse(os.path.isdir(db_path))
 
     def test_dump(self):
         """Test/ example of dump and retrieve from a MongoDB database."""


### PR DESCRIPTION
Every merg_dict operation deep copies dictionaries to act as a failsafe for dictionary mutation.

Unit tests have been made to be copy-paste able examples for people to use, rather than referencing self all the time as you would normally to make it easier to generalize. Sacrifices have to be made to ensure people can understand things.