### PR TITLE
Added delete, and delete test, and donate delete

### DIFF
--- a/ezdb/mongo.py
+++ b/ezdb/mongo.py
@@ -633,7 +633,8 @@ class Mongo(object):
                                 "db": database.Database,
                                 "return": list}
 
-    def donate(self, other, other_collection, db_data_cursor=None, sum=None):
+    def donate(self, other, other_collection, db_collection_name,
+               db_data_cursor=None, sum=None):
         """Donate documents to another db collection.
 
         Like giving blood, we are not getting anything back to self, other
@@ -646,12 +647,17 @@ class Mongo(object):
                 try:
                     other.dump(db_collection_name=other_collection, data=doc)
                     docs_donated.append(doc["_id"])
+                    self.deleteId(id=doc["_id"],
+                                  db_collection_name=db_collection_name)
                 except errors.DuplicateKeyError:
                     self.args["pylog"]("WARN: duplicate: {}".format(doc["id"]))
                 if(count % 10 == 0) and sum:
                     self.args["pylog"]("{}/{}".format(count, sum))
                 count = count + 1
         return docs_donated
+
+    def deleteId(self, id, db_collection_name):
+        return self.args["db"][db_collection_name].delete_one({"_id": id})
 
     def _nextBatch(self, cursor, db_batch_size):
         """Return the very next batch in mongoDb cursor."""

--- a/unit_test.py
+++ b/unit_test.py
@@ -84,6 +84,25 @@ class Mongo_tests(unittest.TestCase):
                 # read file and check is equal to what we put in
                 self.assertEqual(grid["gridout"].read(), b'success')
 
+    def test_delete(self):
+        """Test that we can delete items from db correctly by id."""
+        from ezdb.mongo import Mongo
+
+        db = Mongo({"pylog": null_printer})
+        self.assertIsInstance(db, Mongo)
+        db.connect()
+        db.dump(db_collection_name="test", data={"success": 1})
+        cursor = db.getCursor(db_collection_name="test")
+        for batch in db.getBatches(db_data_cursor=cursor):
+            self.assertEqual(len(batch), 1)
+            for doc in batch:
+                self.assertEqual(doc["success"], 1)
+                db.deleteId(db_collection_name="test", id=doc["_id"])
+
+        cursor = db.getCursor(db_collection_name="test")
+        deleted_collection = list(db.getBatches(db_data_cursor=cursor))
+        self.assertEqual(deleted_collection, [])
+
 
 def null_printer(*text, log_min_level=None,
                  log_delimiter=None):


### PR DESCRIPTION
Donate will now delete donated entries, so this can be usefull for
database backups where the initial db is size restricted for some
reason. Towards this end deleteId has been implemented to delete an
entry by a given id. To check this functionality a unit-test has been
made to vet it, / to allow vetting.