### PR TITLE
Added deletion for duplicates

### DIFF
--- a/ezdb/mongo.py
+++ b/ezdb/mongo.py
@@ -652,6 +652,8 @@ class Mongo(object):
                 except errors.DuplicateKeyError:
                     self.args["pylog"]("WARN: duplicate: {}".format(
                         doc["_id"]))
+                    self.deleteId(id=doc["_id"],
+                                  db_collection_name=db_collection_name)
                 if(count % 10 == 0) and sum:
                     self.args["pylog"]("{}/{}".format(count, sum))
                 count = count + 1


### PR DESCRIPTION
Ok so this one might be a bit controversial but I have added deletion of
duplicates to handling of duplicate key error, this means if the ID
exists in both it will not copy, but instead just delete. However one
might look at that and think, hmm so if it succeeds or not the document
is being deleted, well you would be correct, HOWEVER not ever error is
going to still delete, and if we add more error handling to the end of
the try except statement I want it to be explicitly enabled for an error
based on its relevance rather than the possibility of adding in  other
error handling but still deleting the document for an error that means
the document doesnt exist in the other db, lets say timed out
connecting. If I add another error handler for timeout but forget to
remove the deletion, then now we have a scenario where documents are
gone forever!